### PR TITLE
pre-filter text templates the same as pdf

### DIFF
--- a/src/routes/assemble-utils.js
+++ b/src/routes/assemble-utils.js
@@ -52,9 +52,6 @@ const isPdfTemplate = template =>
 
 function filterTemplatesByCondition (answers) {
   return function (template) {
-    if (!isPdfTemplate(template)) {
-      return true // Rich text templates do this logic in the SSR side
-    }
     const {state} = template.rootNode
     if (!state.hasConditionalLogic) {
       return true


### PR DESCRIPTION
Text templates are now rendered one to a page, whereas previously they would just append content to the previous render/pages. Because of this change, they can now use the same decision logic to check the full page render conditional before the page is submitted, filtering them out the same way PDF based templates are.