### PR TITLE
23 parse header variables

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9126,6 +9126,21 @@
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.0.tgz",
       "integrity": "sha512-8dG4H5ujfvFiqDmVu9fQ5bOHUC15JMjMY/Zumv26oOvvVJjM67KF8koCWIabKQ1GJIa9r2mMZscBq/TbdOcmNA=="
     },
+    "node-html-parser": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/node-html-parser/-/node-html-parser-2.0.0.tgz",
+      "integrity": "sha512-3wJdYSxiVIBxuiFm9UtfNWAlBw2P+Vb/RN1nqf40q2JeZDpcJ1HsrWuWV3j15SSJ25TvfnOoac2Q+uDU9iY0sw==",
+      "requires": {
+        "he": "1.2.0"
+      },
+      "dependencies": {
+        "he": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
+          "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw=="
+        }
+      }
+    },
     "node-pre-gyp": {
       "version": "0.10.3",
       "resolved": "https://registry.npmjs.org/node-pre-gyp/-/node-pre-gyp-0.10.3.tgz",

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "build:server": "steal-tools build",
     "start": "NODE_ENV=production node ./bin/www",
     "dev": "npm run build && node ./bin/www",
+    "dev:debug": "npm run build && DEBUG=A2J:* node --inspect ./bin/www",
     "build:viewer-zip": "node ./bin/make-viewer-package",
     "build:dat-zip": "node ./bin/make-dat-package",
     "build:client": "grunt build --gruntfile=js/Gruntfile.js",

--- a/package.json
+++ b/package.json
@@ -121,6 +121,7 @@
     "moment": "^2.10.3",
     "morgan": "^1.9.1",
     "multer": "^1.3.0",
+    "node-html-parser": "^2.0.0",
     "q": "^1.4.1",
     "request": "^2.69.0",
     "serve-favicon": "^2.5.0",

--- a/test/routes/assemble-utils.js
+++ b/test/routes/assemble-utils.js
@@ -1,0 +1,37 @@
+const assert = require('assert')
+
+const {
+  getHeaderFooterNode,
+  parseHeaderFooterHTML
+} = require('../../src/routes/assemble-utils')
+
+describe('assemble-utils test', function () {
+  it('getHeaderFooterNode', () => {
+    const headerHtml = `<p>line 1 client <strong>last</strong> name:&nbsp;<a2j-variable name="Client last name TE"></a2j-variable><br />
+    line 2 client <u>middle</u> name:&nbsp;<a2j-variable name="Client middle name TE"></a2j-variable></p>`
+
+    const headerNodeRoot = getHeaderFooterNode(headerHtml)
+    const headerNodeVars = headerNodeRoot.querySelectorAll('a2j-variable')
+
+    assert.equal(headerNodeVars.length, 2, 'should allow query of basic DOM tree')
+  })
+
+  it('parseHeaderFooterHTML', () => {
+    const headerHtml = `<p>line 1 client <strong>last</strong> name:&nbsp;<a2j-variable name="Client last name TE"></a2j-variable><br />
+    line 2 client <u>middle</u> name:&nbsp;<a2j-variable name="Client first name TE"></a2j-variable>
+    line 3 client <u>middle</u> name:&nbsp;<a2j-variable name="Client middle name TE"></a2j-variable></p>`
+
+    const firstNameAnswer = { name: 'client first name te', values: [null, 'Ponce'] }
+    const lastNameAnswer = { name: 'client last name te', values: [null, 'De Leon'] }
+    const answers = { 'client first name te': firstNameAnswer, 'client last name te': lastNameAnswer }
+
+    const headerNodeRoot = getHeaderFooterNode(headerHtml)
+
+    const parsedHtml = parseHeaderFooterHTML(headerNodeRoot, answers)
+    const containsFirstName = parsedHtml.indexOf('Ponce') !== -1
+    const containsLastName = parsedHtml.indexOf('De Leon') !== -1
+
+    assert.ok(containsFirstName, 'should add first name to parsed html')
+    assert.ok(containsLastName, 'should add last name to parsed html')
+  })
+})


### PR DESCRIPTION
This checks for <a2j-variable> tags in Text template headers & footers and adds the answer value to that tags `textContent` if the answer value exists. Headers/Footers are handled separately so the replacement needs to happen directly in the html string before the header or footer is sent to wkhtmltopdf for rendering.

closes #23 