### PR TITLE
28 production dat styles

### DIFF
--- a/server.stache
+++ b/server.stache
@@ -2,10 +2,8 @@
   <head>
     <meta charset="UTF-8" />
     <title>{{title}}</title>
-
-    {{! TODO: find a better way to locate the css bundle }}
-    {{! might be something to fix in done-css }}
-    <link rel="stylesheet" href="file:///{{request.__cssBundlePath}}">
+    {{!-- This style tag is replaced with inline styles/style tag during production assembly --}}
+    <style></style>
   </head>
   <body class="bootstrap-styles">
     <can-import from="server" export-as="viewModel" />

--- a/src/routes/assemble-utils.js
+++ b/src/routes/assemble-utils.js
@@ -1,5 +1,6 @@
 const fs = require('fs')
 const path = require('path')
+const files = require('../util/files')
 const uuid = require('uuid')
 const cheerio = require('cheerio')
 const {storage} = require('../pdf/storage')
@@ -192,6 +193,12 @@ function parseHeaderFooterHTML (headerFooterNode, answers) {
   return headerFooterNode.toString()
 }
 
+async function createInlineStyles (path) {
+  const bundleCSS = await files.readFile({ path })
+  const inlineStyles = `<style>\n${bundleCSS}\n</style>`
+  return inlineStyles
+}
+
 module.exports = {
   setDownloadHeaders,
   deleteFile,
@@ -205,5 +212,6 @@ module.exports = {
   getConfigPdfOptions,
   setWkhtmltopdfCommand,
   getHeaderFooterNode,
-  parseHeaderFooterHTML
+  parseHeaderFooterHTML,
+  createInlineStyles
 }

--- a/src/routes/assemble.js
+++ b/src/routes/assemble.js
@@ -265,8 +265,18 @@ async function renderPdfForTextTemplates (templates, req, fileDataUrl, answers) 
 }
 
 async function createPdfForTextTemplate (request, pdfOptions) {
-  const renderedWebpage = await getHtmlForRichText(request)
+  let renderedWebpage = await getHtmlForRichText(request)
+  // inline the css
+  const inlineStyles = await createInlineStyles(request.__cssBundlePath)
+  renderedWebpage = renderedWebpage.replace('<style></style>', inlineStyles)
+
   return getPdfForHtml(renderedWebpage, pdfOptions)
+}
+
+export async function createInlineStyles (path) {
+  const bundleCSS = await files.readFile({ path })
+  const inlineStyles = `<style>\n${bundleCSS}\n</style>`
+  return inlineStyles
 }
 
 function getHtmlForRichText (request) {

--- a/src/routes/assemble.js
+++ b/src/routes/assemble.js
@@ -32,7 +32,8 @@ const {
   getConfigPdfOptions,
   setWkhtmltopdfCommand,
   getHeaderFooterNode,
-  parseHeaderFooterHTML
+  parseHeaderFooterHTML,
+  createInlineStyles
 } = require('./assemble-utils')
 
 const debug = require('debug')('A2J:assemble')
@@ -271,12 +272,6 @@ async function createPdfForTextTemplate (request, pdfOptions) {
   renderedWebpage = renderedWebpage.replace('<style></style>', inlineStyles)
 
   return getPdfForHtml(renderedWebpage, pdfOptions)
-}
-
-export async function createInlineStyles (path) {
-  const bundleCSS = await files.readFile({ path })
-  const inlineStyles = `<style>\n${bundleCSS}\n</style>`
-  return inlineStyles
 }
 
 function getHtmlForRichText (request) {

--- a/src/util/files.js
+++ b/src/util/files.js
@@ -181,5 +181,21 @@ module.exports = {
     })
 
     return deferred.promise
+  },
+
+  readFile ({ path }) {
+    return new Promise((resolve, reject) => {
+      fs.readFile(path, {encoding: 'utf8'}, (error, text) => {
+        if (error) {
+          const isFileNotFound = error.code === 'ENOENT'
+          if (isFileNotFound) {
+            return resolve('')
+          }
+          return reject(error)
+        }
+
+        resolve(text)
+      })
+    })
   }
 }

--- a/src/util/files.js
+++ b/src/util/files.js
@@ -189,6 +189,7 @@ module.exports = {
         if (error) {
           const isFileNotFound = error.code === 'ENOENT'
           if (isFileNotFound) {
+            console.error('File not found at path: ', path)
             return resolve('')
           }
           return reject(error)

--- a/test/routes/assemble-utils.js
+++ b/test/routes/assemble-utils.js
@@ -1,8 +1,12 @@
 const assert = require('assert')
+const sinon = require('sinon')
+const Q = require('q')
+const files = require('../../src/util/files')
 
 const {
   getHeaderFooterNode,
-  parseHeaderFooterHTML
+  parseHeaderFooterHTML,
+  createInlineStyles
 } = require('../../src/routes/assemble-utils')
 
 describe('assemble-utils test', function () {
@@ -33,5 +37,19 @@ describe('assemble-utils test', function () {
 
     assert.ok(containsFirstName, 'should add first name to parsed html')
     assert.ok(containsLastName, 'should add last name to parsed html')
+  })
+
+  it('createInlineStyles', async () => {
+    const readFilePromise = Q.defer()
+    const readFileStub = sinon.stub(files, 'readFile')
+    readFileStub.returns(readFilePromise.promise)
+    readFilePromise.resolve('body{background:#ababab;}')
+
+    const inlineStyles = await createInlineStyles('../data/testCSS.css')
+    console.log('inlineStyles', inlineStyles)
+    const expectedResult = `<style>\nbody{background:#ababab;}\n</style>`
+
+    assert.equal(inlineStyles, expectedResult, 'should read minfied css file and insert into style tag')
+    readFileStub.restore()
   })
 })

--- a/test/routes/assemble-utils.js
+++ b/test/routes/assemble-utils.js
@@ -46,7 +46,6 @@ describe('assemble-utils test', function () {
     readFilePromise.resolve('body{background:#ababab;}')
 
     const inlineStyles = await createInlineStyles('../data/testCSS.css')
-    console.log('inlineStyles', inlineStyles)
     const expectedResult = `<style>\nbody{background:#ababab;}\n</style>`
 
     assert.equal(inlineStyles, expectedResult, 'should read minfied css file and insert into style tag')


### PR DESCRIPTION
Production DAT minified build was not using the minified styles as it was just a `<link>` tag in the html, but was being passed directly to `wkhtmltopdf` without any loading/processing that a browser would do to resolve that link tag. This fix replaces an empty `<style>` tag in `server.stache` with the string version of the minified css files from the bundle, adding them inline to the final html for the template which is then rendered correctly by `wkhtmltopdf`.

closes #28