### PR TITLE
updated script to make zipped release of dat

### DIFF
--- a/bin/make-dat-package
+++ b/bin/make-dat-package
@@ -1,0 +1,72 @@
+#!/usr/bin/env node
+
+var path = require('path')
+var fs = require('fs-extra')
+var chalk = require('chalk')
+var archiver = require('archiver')
+var pjson = require('../package.json')
+var version = pjson.version
+
+var datPath = path.join(__dirname, '..')
+var outputPath = path.join(datPath, '..', 'a2j-dat')
+
+// remove any existing build first
+fs.removeSync(outputPath)
+
+makePackageFolder()
+makePackageZip()
+
+function makePackageFolder () {
+  fs.mkdirSync(outputPath)
+
+  // copy the www script only from bin
+  fs.copySync(path.join(datPath, 'bin', 'www'),
+    path.join(outputPath, 'bin', 'www'))
+
+  // copy node src files
+  fs.copySync(path.join(datPath, 'src'),
+    path.join(outputPath, 'src'))
+
+  // copy node pdf files, ignore files in temp folder
+  const filterFunc = (src, dest) => {
+    if (src.indexOf('temp') > -1) {
+      return fs.statSync(src).isDirectory()
+    } else {
+      return true
+    }
+  }
+  fs.copySync(path.join(datPath, 'pdf'),
+    path.join(outputPath, 'pdf'),
+    { filter: filterFunc })
+
+  // copy package.json  and shrinkwrap to server
+  fs.copySync(path.join(datPath, 'package.json'),
+    path.join(outputPath, 'package.json'))
+  fs.copySync(path.join(datPath, 'package-lock.json'),
+    path.join(outputPath, 'package-lock.json'))
+
+  // copy server.stache and server.js
+  fs.copySync(path.join(datPath, 'server.stache'),
+    path.join(outputPath, 'server.stache'))
+  fs.copySync(path.join(datPath, 'server.js'),
+    path.join(outputPath, 'server.js'))
+
+  // copy shared styles required by the getCSSBundle call
+  fs.copySync(path.join(datPath, 'styles'),
+    path.join(outputPath, 'styles'))
+}
+
+function makePackageZip () {
+  var zip = archiver('zip')
+  var timestamp = (new Date()).toISOString().substr(0, 10)
+  var zipname = 'a2j-dat_' + version + '_' + timestamp + '.zip'
+  var output = fs.createWriteStream(path.join(datPath, '..', zipname))
+
+  output.on('close', function () {
+    fs.removeSync(path.join(outputPath))
+    console.log(chalk.green('A2J DAT distributable package generated successfully!'))
+  })
+
+  zip.pipe(output)
+  zip.directory(outputPath, 'a2j-dat').finalize()
+}

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "build": "babel src --out-dir lib --quiet",
     "build:server": "steal-tools build",
     "deploy": "npm install && npm run build && npm run build:server",
+    "build:dat-zip": "node ./bin/make-dat-package",
     "start": "NODE_ENV=production node ./bin/www",
     "dev": "npm run build && node ./bin/www",
     "dev:debug": "npm run build && DEBUG=A2J:* node --inspect ./bin/www",


### PR DESCRIPTION
This re-adds the make-dat-package script to the /bin directory and an npm script to fire it in package.json. New name includes dat version number pulled from package.json.
