### PR TITLE
54 grouped variables pdf template

### DIFF
--- a/src/pdf/overlayer/validate.js
+++ b/src/pdf/overlayer/validate.js
@@ -4,6 +4,7 @@ const {checks} = require('./checks')
 
 const nonNegative = joi.number().min(0).required()
 const contentString = joi.string().required()
+const allowEmptyString = joi.string().allow('').required()
 const arrayOf = type => joi.array().items(type).required()
 const mustBe = val => joi.any().valid(val).required()
 const oneOf = vals => joi.any().valid(vals).required()
@@ -41,7 +42,7 @@ const OverflowOptions = struct({
   ]),
 
   // ignored if style is "clip-overflow"
-  addendumLabel: contentString
+  addendumLabel: allowEmptyString
 })
 
 const Text = struct({
@@ -67,7 +68,7 @@ const MultilineText = struct({
 const TableText = struct({
   type: mustBe('table-text'),
   columns: matrix(Text),
-  addendumLabel: contentString,
+  addendumLabel: allowEmptyString,
 
   // each text.area.top is ignored for placement
   // columns are placed dynamically on the addendum
@@ -106,7 +107,8 @@ const Overlay = struct({
 })
 
 function validate (overlay) {
-  return joi.validate(overlay, Overlay).error
+  let errorVariable = joi.validate(overlay, Overlay).error
+  return errorVariable
 }
 
 module.exports = {validate}

--- a/src/pdf/overlayer/validate.js
+++ b/src/pdf/overlayer/validate.js
@@ -107,8 +107,7 @@ const Overlay = struct({
 })
 
 function validate (overlay) {
-  let errorVariable = joi.validate(overlay, Overlay).error
-  return errorVariable
+  return joi.validate(overlay, Overlay).error
 }
 
 module.exports = {validate}

--- a/test/pdf/helpers/validate.js
+++ b/test/pdf/helpers/validate.js
@@ -1,0 +1,70 @@
+module.exports = {
+  overlayObject: {
+    'addendum': {
+      'margins': {
+        'top': 0,
+        'left': 0,
+        'right': 0,
+        'bottom': 0
+      },
+      'pageSize': {
+        'width': 612,
+        'height': 792
+      },
+      'labelStyle': {
+        'fontSize': 10,
+        'fontName': 'Lato',
+        'textAlign': 'left',
+        'textColor': '000000'
+      }
+    },
+    'patches': [
+      {
+        'type': 'multiline-text',
+        'content': 'Her, spread out over multiple lines. Hopefully we get to see the error.',
+        'overflow': {
+          'style': 'clip-overflow',
+          'addendumLabel': 'real string'
+        },
+        'addendumText': {
+          'fontSize': 12,
+          'fontName': 'Lato',
+          'textAlign': 'left',
+          'textColor': '000000'
+        },
+        'lines': [
+          {
+            'page': 0,
+            'area': {
+              'top': 619.2,
+              'left': 87.2,
+              'width': 234.4,
+              'height': 14.4
+            },
+            'text': {
+              'fontSize': 12,
+              'fontName': 'Lato',
+              'textAlign': 'left',
+              'textColor': '000000'
+            }
+          },
+          {
+            'page': 0,
+            'area': {
+              'top': 635.2,
+              'left': 71.2,
+              'width': 344,
+              'height': 13.600000000000001
+            },
+            'text': {
+              'fontSize': 12,
+              'fontName': 'Lato',
+              'textAlign': 'left',
+              'textColor': '000000'
+            }
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/test/pdf/overlayer/validate.js
+++ b/test/pdf/overlayer/validate.js
@@ -1,0 +1,34 @@
+const test = require('ava')
+
+const { validate } = require('../../../src/pdf/overlayer/validate')
+
+const { overlayObject } = require('../helpers/validate')
+
+test('validate works for strings', t => {
+  let result = validate(overlayObject)
+  t.is(result, null)
+})
+
+test('validate works for empty strings', t => {
+  overlayObject.patches[0].overflow.addendumLabel = ''
+  let result = validate(overlayObject)
+  t.is(result, null)
+})
+
+test('validate should fail for number', t => {
+  overlayObject.patches[0].overflow.addendumLabel = 2
+  let results = !validate(overlayObject)
+  t.is(results, false)
+})
+
+test('validate should fail for null', t => {
+  overlayObject.patches[0].overflow.addendumLabel = null
+  let results = !validate(overlayObject)
+  t.is(results, false)
+})
+
+test('validate should fail for undefined', t => {
+  overlayObject.patches[0].overflow.addendumLabel = undefined
+  let results = !validate(overlayObject)
+  t.is(results, false)
+})


### PR DESCRIPTION
- Updated validation for addendum labels in PDF templates.

- Tests for addendum label being `null`, `undefined` , `number`, `empty string`, 'regular string`.
