### PR TITLE
header margin restored when footer is added

### DIFF
--- a/src/routes/assemble-utils.js
+++ b/src/routes/assemble-utils.js
@@ -118,6 +118,7 @@ function getRequestPdfOptions (req) {
   } = req.body
 
   const pdfOptions = {}
+  pdfOptions['header-html'] = `${headerFooterUrl}${encodeURIComponent(header)}&hideOnFirstPage=true`
 
   if (header) {
     const h = encodeURIComponent(header)


### PR DESCRIPTION
In a text template with only footer the margin for header gets removed, resulting in a misaligned document. Added the header with `hide=true` by default. 