### PR TITLE
Simplify the logic in /assemble

### DIFF
--- a/src/routes/assemble-utils.js
+++ b/src/routes/assemble-utils.js
@@ -24,6 +24,22 @@ function deleteFile (filepath) {
   })
 }
 
+function getErrorForAnswers (answers) {
+  if (answers === undefined) {
+    return 'You must provide the answers property in the request body'
+  }
+  try {
+    const parsed = JSON.parse(answers)
+    if (parsed instanceof Object) {
+      return ''
+    } else {
+      return 'Answers must be a valid stringified JSON object'
+    }
+  } catch (error) {
+    return `Failed to parse answers with error: ${error}`
+  }
+}
+
 function getTemporaryPdfFilepath () {
   return path.join(storage.getTemporaryDirectory(), `test-${uuid.v4()}.pdf`)
 }
@@ -204,6 +220,7 @@ async function createInlineStyles (path) {
 module.exports = {
   setDownloadHeaders,
   deleteFile,
+  getErrorForAnswers,
   getTemporaryPdfFilepath,
   mergeGuideVariableWithAnswers,
   filterTemplatesByCondition,

--- a/test/routes/assemble-utils.js
+++ b/test/routes/assemble-utils.js
@@ -5,12 +5,32 @@ const files = require('../../src/util/files')
 
 const {
   getHeaderFooterNode,
+  getErrorForAnswers,
   parseHeaderFooterHTML,
   createInlineStyles,
   filterTemplatesByCondition
 } = require('../../src/routes/assemble-utils')
 
 describe('assemble-utils test', function () {
+  describe('getErrorForAnswers', function () {
+    it('returns an error when answers is not provided', function () {
+      const error = getErrorForAnswers()
+      assert.equal(error, 'You must provide the answers property in the request body')
+    })
+    it('returns an error when answers is not parsed as an object', function () {
+      const error = getErrorForAnswers('true')
+      assert.equal(error, 'Answers must be a valid stringified JSON object')
+    })
+    it('returns an error when answers cannot be parsed', function () {
+      const error = getErrorForAnswers('{')
+      assert.match(error, /Failed to parse answers with error/)
+    })
+    it('returns an empty string when answers is valid', function () {
+      const error = getErrorForAnswers('{}')
+      assert.equal(error, '')
+    })
+  })
+
   it('getHeaderFooterNode', () => {
     const headerHtml = `<p>line 1 client <strong>last</strong> name:&nbsp;<a2j-variable name="Client last name TE"></a2j-variable><br />
     line 2 client <u>middle</u> name:&nbsp;<a2j-variable name="Client middle name TE"></a2j-variable></p>`

--- a/test/routes/assemble.js
+++ b/test/routes/assemble.js
@@ -1,12 +1,40 @@
 const app = require('../../src/app')
+const path = require('path')
 const request = require('supertest')
 
 describe('POST /api/assemble', function () {
+  it('fails if answers is missing', function (done) {
+    request(app)
+      .post('/api/assemble')
+      .send({ answers: null, guideId: '1262' })
+      .expect(400, 'Answers must be a valid stringified JSON object')
+      .end(function (err) {
+        if (err) return done(err)
+        done()
+      })
+  })
   it('fails if guideId and fileDataUrl are missing', function (done) {
     request(app)
       .post('/api/assemble')
-      .send({ guideId: null, fileDataUrl: null })
+      .send({ answers: '{}', fileDataUrl: null, guideId: null })
       .expect(400, 'You must provide either guideId or fileDataUrl')
+      .end(function (err) {
+        if (err) return done(err)
+        done()
+      })
+  })
+  it('assembles basic templates correctly', function (done) {
+    // Set a longer timeout, otherwise the PDF generation will fail
+    this.timeout(5000)
+
+    const fileDataUrl = path.join(__dirname, '..', 'data', 'DEV', 'guides', 'Guide1262')
+    request(app)
+      .post('/api/assemble')
+      .send({
+        answers: '{}',
+        fileDataUrl
+      })
+      .expect(200)
       .end(function (err) {
         if (err) return done(err)
         done()


### PR DESCRIPTION
Previously, the logic inside `assemble` had two paths that did similar things: render text templates, set download headers, send the file, etc.

Now, the logic for getting the templates remains different, but rendering and sending the file is the same.

This also includes:

- An assertion that `answers` is provided (it can be an empty object, but it has to be provided)
- Changes to `combinePdfFiles` so it doesn’t create the writer when it’s only passed one PDF that won’t be modified
- Happy-path tests for rendering text templates to PDF

Part of https://github.com/CCALI/a2jdat/issues/94