### PR TITLE
Add a script for starting Mocha with the Node debugger

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "dev": "npm run build && node ./bin/www",
     "dev:debug": "npm run build && DEBUG=A2J:* node --inspect ./bin/www",
     "mocha": "mocha test/routes test/util --require babel-register --exit",
+    "mocha:inspect": "node --inspect-brk node_modules/.bin/mocha test/routes test/util --require babel-register --exit",
     "mocha:watch": "mocha test/routes test/util --require babel-register --watch",
     "test:pdf": "npm run build && babel test --out-dir test-lib --quiet && ava --serial",
     "lint:pdf": "standard src/*.js src/**/*.js --fix && standard test/**/*.js --fix --env mocha"


### PR DESCRIPTION
Running this script allows you to open a Node debugger in an inspector, e.g. Chrome: https://nodejs.org/en/docs/guides/debugging-getting-started/