### PR TITLE
Move the helper functions for /assemble to assemble-utils

### DIFF
--- a/src/routes/assemble-utils.js
+++ b/src/routes/assemble-utils.js
@@ -1,13 +1,45 @@
+const {getTemplateOverlay} = require('@caliorg/a2jdeps/pdf/assemble')
+const ssr = require('done-ssr')
 const fs = require('fs')
+const he = require('he')
+const hummus = require('muhammara')
 const path = require('path')
+const through = require('through2')
 const files = require('../util/files')
 const uuid = require('uuid')
 const cheerio = require('cheerio')
+const {overlayer} = require('../pdf/overlayer')
 const {storage} = require('../pdf/storage')
 const debug = require('debug')('A2J:assemble')
 const wkhtmltopdf = require('wkhtmltopdf')
 const { parse } = require('node-html-parser')
 const evalAuthorCondition = require('@caliorg/a2jdeps/utils/eval-author-condition')
+const templates = require('../routes/templates')
+const {data} = require('../util/data')
+const getCssBundlePath = require('../util/get-css-bundle-path')
+const paths = require('../util/paths')
+
+const configPath = path.join(__dirname, '..', '..', 'package.json!npm')
+debug('SSR configPath', configPath)
+
+const render = ssr({
+  main: 'a2jdat/server.stache!done-autorender',
+  config: configPath
+}, {
+  // this allows for debugging in Node --inspect-brk
+  // setting a max of 20 seconds before done-ssr times out
+  // this does not prevent done-ssr from finishing earlier if
+  // the render is complete.
+  //
+  timeout: 20000
+})
+
+const config = getConfig()
+let configPdfOptions = {}
+if (config) {
+  setWkhtmltopdfCommand(config)
+  configPdfOptions = getConfigPdfOptions(config)
+}
 
 function setDownloadHeaders (res, filename) {
   res.set({
@@ -16,6 +48,46 @@ function setDownloadHeaders (res, filename) {
     'Access-Control-Allow-Origin': '*',
     'Content-Disposition': `attachment; filename=${filename}`
   })
+}
+
+function checkPresenceOf (req, res, next) {
+  const { answers, fileDataUrl, guideId } = req.body
+
+  const answersError = getErrorForAnswers(answers)
+  if (answersError) {
+    return res.status(400)
+      .send(answersError)
+  }
+
+  if (!guideId && !fileDataUrl) {
+    return res.status(400)
+      .send('You must provide either guideId or fileDataUrl')
+  }
+
+  next()
+}
+
+async function combinePdfFiles (pdfFiles) {
+  const [firstPdf, ...otherPdfs] = pdfFiles
+
+  if (otherPdfs.length > 0) {
+    const writer = hummus.createWriterToModify(firstPdf)
+    otherPdfs.forEach(pdf => {
+      writer.appendPDFPagesFromPDF(pdf)
+    })
+    writer.end()
+  }
+
+  return firstPdf
+}
+
+async function createPdfForTextTemplate (request, pdfOptions) {
+  let renderedWebpage = await getHtmlForRichText(request)
+  // inline the css
+  const inlineStyles = await createInlineStyles(request.__cssBundlePath)
+  renderedWebpage = renderedWebpage.replace('<style></style>', inlineStyles)
+
+  return getPdfForHtml(renderedWebpage, pdfOptions)
 }
 
 function deleteFile (filepath) {
@@ -40,8 +112,127 @@ function getErrorForAnswers (answers) {
   }
 }
 
+function getHtmlForRichText (request) {
+  const webpageStream = render(request)
+  return new Promise((resolve, reject) => {
+    webpageStream.pipe(through(buffer => {
+      const html = buffer.toString()
+      resolve(he.decode(html))
+    }))
+    webpageStream.on('error', error => reject(error))
+  })
+}
+
+function getPdfForHtml (html, pdfOptions) {
+  return wkhtmltopdf(html, pdfOptions)
+}
+
+async function getSingleTemplate (templateId, fileDataUrl) {
+  return paths.getTemplatePath({ username: '', guideID: '', templateId, fileDataUrl })
+  .then((path) => files.readJSON({ path }))
+}
+
+async function getTemplatesForGuide (username, guideId, fileDataUrl) {
+  const templateIndex = await templates.getTemplatesJSON({username, guideId, fileDataUrl})
+  // if guideId not defined, we are in standalone viewer/dat assembly using fileDataUrl
+  // set guideId to the local templates.json value
+  if (fileDataUrl && !guideId) {
+    guideId = templateIndex.guideId
+  }
+  const templateIds = templateIndex.templateIds
+  const templatesPromises = templateIds
+  .map(templateId => paths
+      .getTemplatePath({guideId, templateId, username, fileDataUrl})
+      .then(path => files.readJSON({path}))
+    )
+
+  const isActive = template =>
+    template.active === 'true' || template.active === true
+
+  return Promise.all(templatesPromises)
+    .then(templates => templates.filter(isActive))
+}
+
 function getTemporaryPdfFilepath () {
   return path.join(storage.getTemporaryDirectory(), `test-${uuid.v4()}.pdf`)
+}
+
+async function getVariablesForGuide (username, guideId, fileDataUrl) {
+  const xml = await data.getGuideXml(username, guideId, fileDataUrl)
+  if (!xml) {
+    return {}
+  }
+  const variables = getXmlVariables(xml)
+  return variables.reduce((map, variable) => {
+    map[variable.name.toLowerCase()] = variable
+    return map
+  }, {})
+}
+
+async function renderPdfForPdfTemplates (username, templates, variables, answers, fileDataUrl) {
+  const pdfFiles = await Promise.all(templates.map(async template => {
+    const filepath = await storage.duplicateTemplatePdf(username, template.guideId, template.templateId, fileDataUrl)
+    const overlay = getTemplateOverlay(template, variables, answers)
+    await overlayer.forkWithOverlay(filepath, overlay)
+    return filepath
+  }))
+
+  return combinePdfFiles(pdfFiles)
+}
+
+async function renderPdfForTextTemplates (templates, req, fileDataUrl, answers) {
+  const __cssBundlePath = getCssBundlePath()
+  const pdfFiles = await Promise.all(templates.map(template => {
+    // resolve any a2j-variable tags with their answers
+    template.header = parseHeaderFooterHTML(getHeaderFooterNode(template.header), answers)
+    template.footer = parseHeaderFooterHTML(getHeaderFooterNode(template.footer), answers)
+
+    // make unique request here for each templateId
+    const newBody = Object.assign({}, req.body,
+      { templateId: template.templateId,
+        header: template.header,
+        hideHeaderOnFirstPage: template.hideHeaderOnFirstPage,
+        footer: template.footer,
+        hideFooterOnFirstPage: template.hideFooterOnFirstPage,
+        fileDataUrl
+      }
+    )
+
+    const donessrRequestObject = Object.assign({}, {
+      url: req.url,
+      protocol: req.protocol,
+      originalUrl: req.originalUrl,
+      get: req.get,
+      headers: req.headers,
+      body: newBody,
+      connection: req.connection,
+      __cssBundlePath: __cssBundlePath
+    })
+
+    const reqPdfOptions = Object.assign({}, getRequestPdfOptions(donessrRequestObject))
+    const pdfOptions = Object.assign({},
+      reqPdfOptions,
+      configPdfOptions,
+      {
+        'header-spacing': 5,
+        'footer-spacing': 5,
+        'margin-top': 20
+      }
+    )
+
+    return createPdfForTextTemplate(donessrRequestObject, pdfOptions).then(pdfStream => {
+      const temporaryPath = getTemporaryPdfFilepath()
+      const fileStream = fs.createWriteStream(temporaryPath)
+      return new Promise((resolve, reject) => {
+        pdfStream.on('error', error => reject(error))
+        fileStream.on('finish', () => resolve(temporaryPath))
+        fileStream.on('error', error => reject(error))
+        pdfStream.pipe(fileStream)
+      })
+    })
+  }))
+
+  return combinePdfFiles(pdfFiles)
 }
 
 function uniq (list) {
@@ -218,10 +409,15 @@ async function createInlineStyles (path) {
 }
 
 module.exports = {
+  checkPresenceOf,
+  combinePdfFiles,
   setDownloadHeaders,
   deleteFile,
   getErrorForAnswers,
+  getSingleTemplate,
+  getTemplatesForGuide,
   getTemporaryPdfFilepath,
+  getVariablesForGuide,
   mergeGuideVariableWithAnswers,
   filterTemplatesByCondition,
   segmentTextAndPdfTemplates,
@@ -232,5 +428,7 @@ module.exports = {
   setWkhtmltopdfCommand,
   getHeaderFooterNode,
   parseHeaderFooterHTML,
+  renderPdfForPdfTemplates,
+  renderPdfForTextTemplates,
   createInlineStyles
 }


### PR DESCRIPTION
The main assemble route module contained a number of helper functions for the `/assemble` route.

Many or all of these helper functions will be useful for the `/preview` route, so this moves them to the `assemble-utils` module for reuse.

Part of https://github.com/CCALI/a2jdat/issues/94