### PR TITLE
Add the lang attribute to html docs

### DIFF
--- a/pdf/assets/checkmark-font-demo/index.html
+++ b/pdf/assets/checkmark-font-demo/index.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html>
+<html lang="en">
 <head>
     <meta charset="utf-8">
     <title>IcoMoon Demo</title>

--- a/server.stache
+++ b/server.stache
@@ -1,4 +1,4 @@
-<html>
+<html lang="en">
   <head>
     <meta charset="UTF-8" />
     <title>{{title}}</title>

--- a/src/pdf/not-found.js
+++ b/src/pdf/not-found.js
@@ -1,5 +1,5 @@
 module.exports = `<!doctype html>
-<html>
+<html lang="en">
   <head>
     <style>
       body {

--- a/styles/documentjs-theme/static/build.html
+++ b/styles/documentjs-theme/static/build.html
@@ -1,4 +1,4 @@
-<html>
+<html lang="en">
 	<body>
 		<script src="../../../node_modules/steal/steal.js"
 				data-config="./config.js"></script>

--- a/styles/icon-font/demo.html
+++ b/styles/icon-font/demo.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
   <head><!--[if lt IE 9]><script language="javascript" type="text/javascript" src="//html5shim.googlecode.com/svn/trunk/html5.js"></script><![endif]-->
     <meta charset="UTF-8"><style>/*
  * Bootstrap v2.2.1


### PR DESCRIPTION
Just `en` (vs. `en-US`) is specified because of the recommendations on https://www.w3.org/International/articles/language-tags/

Closes https://github.com/CCALI/a2jdat/issues/92